### PR TITLE
registration retries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@streamdal/node-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@streamdal/node-sdk",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "workspaces": [
         "examples"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "examples"
   ],
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Streamdal's Node SDK",
   "keywords": [
     "streamdal",

--- a/src/__tests__/pipeline.test.ts
+++ b/src/__tests__/pipeline.test.ts
@@ -14,6 +14,7 @@ import { initPipelines, processResponse } from "../internal/pipeline.js";
 import { audienceKey, internal } from "../internal/register.js";
 
 const testConfigs = {
+  registered: true,
   grpcClient: {
     getAttachCommandsByService: () => ({
       active: [],

--- a/src/internal/grpc.ts
+++ b/src/internal/grpc.ts
@@ -1,0 +1,15 @@
+import { ChannelCredentials } from "@grpc/grpc-js";
+import { GrpcTransport } from "@protobuf-ts/grpc-transport";
+import {
+  IInternalClient,
+  InternalClient,
+} from "@streamdal/protos/protos/sp_internal.client";
+
+export const client = (url: string): IInternalClient => {
+  const transport = new GrpcTransport({
+    host: url,
+    channelCredentials: ChannelCredentials.createInsecure(),
+  });
+
+  return new InternalClient(transport) as IInternalClient;
+};

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -7,6 +7,7 @@ import { IInternalClient } from "@streamdal/protos/protos/sp_internal.client";
 import ReadWriteLock from "rwlock";
 
 import { StepStatus } from "./process.js";
+import { internal } from "./register.js";
 
 export const METRIC_INTERVAL = 1000;
 

--- a/src/internal/pipeline.ts
+++ b/src/internal/pipeline.ts
@@ -16,23 +16,27 @@ export type EnhancedStep = PipelineStep & {
 };
 
 export const initPipelines = async (configs: Configs) => {
-  const { response }: { response: GetAttachCommandsByServiceResponse } =
-    await configs.grpcClient.getAttachCommandsByService(
-      {
-        serviceName: configs.serviceName.toLowerCase(),
-      },
-      { meta: { "auth-token": configs.streamdalToken } }
-    );
+  try {
+    console.debug("initializing pipelines");
+    const { response }: { response: GetAttachCommandsByServiceResponse } =
+      await configs.grpcClient.getAttachCommandsByService(
+        {
+          serviceName: configs.serviceName.toLowerCase(),
+        },
+        { meta: { "auth-token": configs.streamdalToken } }
+      );
 
-  for (const [k, v] of Object.entries(response.wasmModules)) {
-    internal.wasmModules.set(k, v);
-  }
+    for (const [k, v] of Object.entries(response.wasmModules)) {
+      internal.wasmModules.set(k, v);
+    }
 
-  for (const command of response.active) {
-    processResponse(command);
+    for (const command of response.active) {
+      processResponse(command);
+    }
+    internal.pipelineInitialized = true;
+  } catch (e) {
+    console.error("Error initializing pipelines", e);
   }
-  internal.pipelineInitialized = true;
-  return;
 };
 
 export const processResponse = (response: Command) => {

--- a/src/internal/process.ts
+++ b/src/internal/process.ts
@@ -143,6 +143,13 @@ export const processPipeline = async ({
   };
 
   for (const step of allSteps) {
+    if (configs.dryRun) {
+      console.debug(
+        `Dry run set. Found pipeline step ${step.pipelineName} - ${step.name}...not running.`
+      );
+      continue;
+    }
+
     console.debug(
       `running pipeline step ${step.pipelineName} - ${step.name}...`
     );

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -384,6 +384,12 @@ export const exampleMultipleComponentsPerService = async () => {
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/require-await
+export const exampleSimple = async () => {
+  const streamdalA = new Streamdal(serviceAConfig);
+  void logTest(streamdalA, audienceAConsumer, exampleData);
+};
+
 export const exampleStaggeredMultipleComponentsPerServiceAndPerGroup =
   // eslint-disable-next-line @typescript-eslint/require-await
   async () => {
@@ -448,4 +454,4 @@ export const exampleStaggeredMultipleComponentsPerServiceAndPerGroup =
     }, 2000);
   };
 
-void throughputFriendly();
+void tailFriendly();


### PR DESCRIPTION
This is actually pretty difficult to do in node since there is no idiomatic way to await stuff like registration in an object constructor. 

So, I made some compromises and this is how it works:
1. When a `new Streamdal()` constructor is called, initiate a register and store the pending promise. 
2. When a `processPipeline` is called, check if there is an active registration or a pending registration and wait for it to finish if there is, if registration fails, then respond with an error to the pipeline request. 
3. If the initial registration request fails, retry registration asynchronously at a set interval for a set number of times.

#2 should take care of the case where they construct Streamdal() and immediately invoke `processPipeline`
#3 should take care of the case where they have a long running Streamdal() process and the server goes down and comes back.

