### PR TITLE
add register reconnect on error and pipeline retries

### DIFF
--- a/src/internal/grpc.ts
+++ b/src/internal/grpc.ts
@@ -7,14 +7,19 @@ import {
 
 export const GRPC_KEEPALIVE = 2000;
 
-export const client = (url: string): IInternalClient => {
-  const transport = new GrpcTransport({
-    host: url,
-    channelCredentials: ChannelCredentials.createInsecure(),
-    clientOptions: {
-      "grpc.keepalive_time_ms": GRPC_KEEPALIVE,
-    },
-  });
+export const client = (url: string): IInternalClient | null => {
+  try {
+    const transport = new GrpcTransport({
+      host: url,
+      channelCredentials: ChannelCredentials.createInsecure(),
+      clientOptions: {
+        "grpc.keepalive_time_ms": GRPC_KEEPALIVE,
+      },
+    });
 
-  return new InternalClient(transport) as IInternalClient;
+    return new InternalClient(transport) as IInternalClient;
+  } catch (error) {
+    console.error("shit transport error", error);
+  }
+  return null;
 };

--- a/src/internal/grpc.ts
+++ b/src/internal/grpc.ts
@@ -7,19 +7,14 @@ import {
 
 export const GRPC_KEEPALIVE = 2000;
 
-export const client = (url: string): IInternalClient | null => {
-  try {
-    const transport = new GrpcTransport({
-      host: url,
-      channelCredentials: ChannelCredentials.createInsecure(),
-      clientOptions: {
-        "grpc.keepalive_time_ms": GRPC_KEEPALIVE,
-      },
-    });
+export const client = (url: string): IInternalClient => {
+  const transport = new GrpcTransport({
+    host: url,
+    channelCredentials: ChannelCredentials.createInsecure(),
+    clientOptions: {
+      "grpc.keepalive_time_ms": GRPC_KEEPALIVE,
+    },
+  });
 
-    return new InternalClient(transport) as IInternalClient;
-  } catch (error) {
-    console.error("shit transport error", error);
-  }
-  return null;
+  return new InternalClient(transport) as IInternalClient;
 };

--- a/src/internal/heartbeat.ts
+++ b/src/internal/heartbeat.ts
@@ -18,20 +18,29 @@ export const heartbeat = async ({
   sessionId,
   streamdalToken,
 }: HearbeatConfigs) => {
-  const heartbeatRequest = {
-    sessionId,
-    serviceName,
-    audiences: Array.from(internal.audiences.values()).map((a) => a.audience),
-    clientInfo: clientInfo(),
-  };
-  console.debug("sending heartbeat", heartbeatRequest);
+  try {
+    const heartbeatRequest = {
+      sessionId,
+      serviceName,
+      audiences: Array.from(internal.audiences.values()).map((a) => a.audience),
+      clientInfo: clientInfo(),
+    };
+    console.debug("sending heartbeat", heartbeatRequest);
 
-  const call = grpcClient.heartbeat(heartbeatRequest, {
-    meta: { "auth-token": streamdalToken },
-  });
+    const call = grpcClient.heartbeat(heartbeatRequest, {
+      meta: { "auth-token": streamdalToken },
+    });
 
-  const response = await call.response;
-  if (response.code !== ResponseCode.OK) {
-    console.error("Heartbeat error", response.message);
+    const response = await call.response;
+    if (response.code !== ResponseCode.OK) {
+      console.error("Heartbeat error", response.message);
+    }
+  } catch (e) {
+    console.error(
+      `error sending heartbeat to server, will try again in ${
+        HEARTBEAT_INTERVAL / 1000
+      } seconds, error: `,
+      e
+    );
   }
 };

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -7,7 +7,6 @@ import { IInternalClient } from "@streamdal/protos/protos/sp_internal.client";
 import ReadWriteLock from "rwlock";
 
 import { StepStatus } from "./process.js";
-import { internal } from "./register.js";
 
 export const METRIC_INTERVAL = 1000;
 
@@ -101,7 +100,8 @@ export const audienceMetrics = async (
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const sendMetrics = async (configs: MetricsConfigs) =>
-  lock.writeLock((release) => {
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  lock.writeLock(async (release) => {
     try {
       if (!metrics.size) {
         console.debug(`### no metrics found, skipping`);
@@ -116,7 +116,7 @@ export const sendMetrics = async (configs: MetricsConfigs) =>
       }));
       console.debug("sending metrics", metricsData);
 
-      void configs.grpcClient.metrics(
+      await configs.grpcClient.metrics(
         {
           metrics: metricsData,
         },

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -98,10 +98,8 @@ export const audienceMetrics = async (
   });
 };
 
-// eslint-disable-next-line @typescript-eslint/require-await
-export const sendMetrics = async (configs: MetricsConfigs) =>
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  lock.writeLock(async (release) => {
+export const sendMetrics = (configs: MetricsConfigs) =>
+  lock.writeLock((release) => {
     try {
       if (!metrics.size) {
         console.debug(`### no metrics found, skipping`);
@@ -116,7 +114,7 @@ export const sendMetrics = async (configs: MetricsConfigs) =>
       }));
       console.debug("sending metrics", metricsData);
 
-      await configs.grpcClient.metrics(
+      void configs.grpcClient.metrics(
         {
           metrics: metricsData,
         },

--- a/src/streamdal.ts
+++ b/src/streamdal.ts
@@ -2,16 +2,12 @@ import { Audience, OperationType } from "@streamdal/protos/protos/sp_common";
 import { IInternalClient } from "@streamdal/protos/protos/sp_internal.client";
 import { v4 as uuidv4 } from "uuid";
 
-import { addAudience, addAudiences } from "./internal/audience.js";
+import { addAudiences } from "./internal/audience.js";
 import { client } from "./internal/grpc.js";
 import { heartbeat, HEARTBEAT_INTERVAL } from "./internal/heartbeat.js";
 import { METRIC_INTERVAL, sendMetrics } from "./internal/metrics.js";
-import { initPipelines } from "./internal/pipeline.js";
-import {
-  processPipeline as internalProcessPipeline,
-  StepStatus,
-} from "./internal/process.js";
-import { internal, retryRegister } from "./internal/register.js";
+import { retryProcessPipeline, StepStatus } from "./internal/process.js";
+import { register } from "./internal/register.js";
 
 export { Audience, OperationType };
 
@@ -51,7 +47,6 @@ export interface StreamdalResponse {
 
 export class Streamdal {
   private configs: Configs;
-  private register: Promise<boolean | undefined>;
 
   constructor({
     streamdalUrl,
@@ -78,6 +73,12 @@ export class Streamdal {
     const sessionId = uuidv4();
     const grpcClient = client(url);
 
+    if (grpcClient == null) {
+      throw new Error(
+        "connection to the Streamdal server failed, is it running?"
+      );
+    }
+
     this.configs = {
       grpcClient,
       sessionId,
@@ -101,37 +102,13 @@ export class Streamdal {
     }, METRIC_INTERVAL);
 
     void addAudiences(this.configs);
-    //
-    // Since we can't async await in a constructor we assign the promise
-    // here so we can check it and wait for it on the initial pipeline request
-    this.register = retryRegister(this.configs);
+    void register(this.configs);
   }
 
   async processPipeline({
     audience,
     data,
   }: StreamdalRequest): Promise<StreamdalResponse> {
-    if (!internal.registered) {
-      //
-      // Initial server registration may not have completed yet
-      const register = await this.register;
-      if (!register) {
-        const message =
-          "Node SDK not yet registered with the server, skipping pipeline. Is the server running?";
-        console.error(message);
-        return Promise.resolve({
-          data,
-          error: true,
-          message,
-        });
-      }
-    }
-
-    if (!internal.pipelineInitialized) {
-      await initPipelines(this.configs);
-    }
-
-    await addAudience({ configs: this.configs, audience });
-    return internalProcessPipeline({ configs: this.configs, audience, data });
+    return retryProcessPipeline({ configs: this.configs, audience, data });
   }
 }

--- a/src/streamdal.ts
+++ b/src/streamdal.ts
@@ -73,12 +73,6 @@ export class Streamdal {
     const sessionId = uuidv4();
     const grpcClient = client(url);
 
-    if (grpcClient == null) {
-      throw new Error(
-        "connection to the Streamdal server failed, is it running?"
-      );
-    }
-
     this.configs = {
       grpcClient,
       sessionId,


### PR DESCRIPTION
Registrations will retry in 5 seconds on error. Pipelines will retry every second for 10 times if there is no active registration. 