### PR TITLE
re-use tail

### DIFF
--- a/src/internal/process.ts
+++ b/src/internal/process.ts
@@ -1,5 +1,7 @@
+import { ClientStreamingCall } from "@protobuf-ts/runtime-rpc";
 import {
   Audience,
+  StandardResponse,
   TailResponse,
   TailResponseType,
 } from "@streamdal/protos/protos/sp_common";
@@ -33,6 +35,7 @@ export interface PipelinesStatus {
 
 export interface PipelineConfigs {
   grpcClient: IInternalClient;
+  tailCall: ClientStreamingCall<TailResponse, StandardResponse>;
   streamdalToken: string;
   sessionId: string;
   dryRun: boolean;
@@ -68,10 +71,6 @@ export const sendTail = ({
   newData,
 }: TailRequest) => {
   try {
-    const tailCall = configs.grpcClient.sendTail({
-      meta: { "auth-token": configs.streamdalToken },
-    });
-
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     tails?.forEach(async (tailStatus, tailRequestId) => {
       if (tailStatus.tail) {
@@ -85,18 +84,18 @@ export const sendTail = ({
           newData,
         });
         console.debug("sending tail response", tailResponse);
-        await tailCall.requests.send(tailResponse);
+        await configs.tailCall.requests.send(tailResponse);
 
-        const headers = await tailCall.headers;
+        const headers = await configs.tailCall.headers;
         console.debug("got tail response headers: ", headers);
 
-        const response = await tailCall.response;
+        const response = await configs.tailCall.response;
         console.debug("got tail response message: ", response);
 
-        const status = await tailCall.status;
+        const status = await configs.tailCall.status;
         console.debug("got tail status: ", status);
 
-        const trailers = await tailCall.trailers;
+        const trailers = await configs.tailCall.trailers;
         console.debug("got tail trailers: ", trailers);
       }
     });

--- a/src/streamdal.ts
+++ b/src/streamdal.ts
@@ -1,4 +1,10 @@
-import { Audience, OperationType } from "@streamdal/protos/protos/sp_common";
+import { ClientStreamingCall } from "@protobuf-ts/runtime-rpc";
+import {
+  Audience,
+  OperationType,
+  StandardResponse,
+  TailResponse,
+} from "@streamdal/protos/protos/sp_common";
 import { IInternalClient } from "@streamdal/protos/protos/sp_internal.client";
 import { v4 as uuidv4 } from "uuid";
 
@@ -23,6 +29,7 @@ export interface StreamdalConfigs {
 
 export interface Configs {
   grpcClient: IInternalClient;
+  tailCall: ClientStreamingCall<TailResponse, StandardResponse>;
   streamdalUrl: string;
   streamdalToken: string;
   serviceName: string;
@@ -75,6 +82,9 @@ export class Streamdal {
 
     this.configs = {
       grpcClient,
+      tailCall: grpcClient.sendTail({
+        meta: { "auth-token": token },
+      }),
       sessionId,
       streamdalUrl: url,
       streamdalToken: token,


### PR DESCRIPTION
This side steps our mem leak by not opening a new streaming connection per tail request.