### PR TITLE
fix commonjs/esm issue

### DIFF
--- a/examples/commonjs/package.json
+++ b/examples/commonjs/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@streamdal/node-sdk": "^0.1.19",
+    "@streamdal/node-sdk": "^0.1.21",
     "tsc-watch": "^6.0.4",
     "typescript": "^5.1.6"
   }

--- a/examples/esm/package.json
+++ b/examples/esm/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@streamdal/node-sdk": "^0.1.19",
+    "@streamdal/node-sdk": "^0.1.21",
     "tsc-watch": "^6.0.4",
     "typescript": "^5.1.6"
   }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "main": "cjs/streamdal.js",
   "scripts": {
     "build": "npm run clean && npm run build:esm && npm run build:commonjs && ./generatePackages.sh",
-    "build:esm": "npx tsc --module commonjs --outDir build/cjs/",
-    "build:commonjs": "npx tsc --module es2022 --outDir build/esm/",
+    "build:commonjs": "npx tsc --module commonjs --outDir build/cjs/",
+    "build:esm": "npx tsc --module es2022 --outDir build/esm/",
     "clean": "rimraf build",
     "sandbox": "tsc-watch --onSuccess \"node --experimental-wasi-unstable-preview1 ./build/sandbox/index.js\"",
     "lint": "eslint src --ext .ts --fix",


### PR DESCRIPTION
Fix to hopefully get prisma working. I had flip-flopped cjs and esm builds and prisma uses the cjs one.