### PR TITLE
an httpRequest implementation

### DIFF
--- a/src/__tests__/wasm.test.ts
+++ b/src/__tests__/wasm.test.ts
@@ -117,7 +117,7 @@ describe("wasm tests", async () => {
 
   it("attached pipeline detective step should execute wasm", async () => {
     internal.pipelines.set(key, new Map([[testPipeline.id, testPipeline]]));
-    const result = processPipeline({
+    const result = await processPipeline({
       originalData: new TextEncoder().encode(JSON.stringify(testData)),
       audience: testAudience,
       configs: testConfigs,

--- a/src/internal/httpRequest.ts
+++ b/src/internal/httpRequest.ts
@@ -13,7 +13,12 @@ export const httpRequest = async ({ step }: { step: PipelineStep }) => {
     headers: step.step.httpRequest.request.headers,
   });
 
-  const body = await response.json();
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    console.debug("could not parse http request response body");
+  }
 
   return {
     outputStep: null,
@@ -21,7 +26,7 @@ export const httpRequest = async ({ step }: { step: PipelineStep }) => {
     exitCode: response.ok
       ? WASMExitCode.WASM_EXIT_CODE_TRUE
       : WASMExitCode.WASM_EXIT_CODE_ERROR,
-    exitMsg: JSON.stringify(body),
+    ...(body ? { exitMsg: JSON.stringify(body) } : {}),
     interStepResult: undefined,
   };
 };

--- a/src/internal/httpRequest.ts
+++ b/src/internal/httpRequest.ts
@@ -1,0 +1,27 @@
+import { PipelineStep } from "@streamdal/protos/protos/sp_pipeline";
+import { WASMExitCode } from "@streamdal/protos/protos/sp_wsm";
+import { HttpRequestMethod } from "@streamdal/protos/protos/steps/sp_steps_httprequest";
+
+export const httpRequest = async ({ step }: { step: PipelineStep }) => {
+  if (step.step.oneofKind !== "httpRequest" || !step.step.httpRequest.request) {
+    throw new Error("not a valid httpRequest");
+  }
+
+  const response = await fetch(step.step.httpRequest.request.url, {
+    method: HttpRequestMethod[step.step.httpRequest.request.method],
+    body: new TextDecoder().decode(step.step.httpRequest.request.body),
+    headers: step.step.httpRequest.request.headers,
+  });
+
+  const body = await response.json();
+
+  return {
+    outputStep: null,
+    outputPayload: new Uint8Array(),
+    exitCode: response.ok
+      ? WASMExitCode.WASM_EXIT_CODE_TRUE
+      : WASMExitCode.WASM_EXIT_CODE_ERROR,
+    exitMsg: JSON.stringify(body),
+    interStepResult: undefined,
+  };
+};

--- a/src/internal/wasm.ts
+++ b/src/internal/wasm.ts
@@ -21,6 +21,14 @@ const wasi = new WASI({
   },
 } as any);
 
+//
+// We bypass wasm for some things in node (async) but we still
+// need to have a host function mapped so wasm instantiation
+// doesn't blow up.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const hostFunctionNOOP = (_: any, __: number, ____: number): bigint =>
+  BigInt(0);
+
 export const instantiateWasm = async (
   wasmId?: string,
   wasmBytes?: Uint8Array
@@ -41,6 +49,8 @@ export const instantiateWasm = async (
     env: {
       kvExists: (pointer: number, length: number): bigint =>
         kvExists(instantiated.exports, pointer, length),
+      httpRequest: (pointer: number, length: number): bigint =>
+        hostFunctionNOOP(instantiated.exports, pointer, length),
     },
   });
   internal.wasmModules.set(wasmId, instantiated);

--- a/src/sandbox/billing.ts
+++ b/src/sandbox/billing.ts
@@ -132,3 +132,9 @@ export const billingExample = () => {
   randomPipelineAndData(welcome, welcomeConsumer, sData);
   randomPipelineAndData(welcome, welcomeProducer, wpData);
 };
+
+export const singleWelcomeExample = () => {
+  const welcome = new Streamdal(serviceWelcomeConfig);
+  const wpData = loadData("./src/sandbox/assets/sample-welcome-producer.json");
+  randomPipelineAndData(welcome, welcomeProducer, wpData);
+};

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -396,3 +396,4 @@ export const exampleStaggeredMultipleComponentsPerServiceAndPerGroup = () => {
 //
 // kv();
 billingExample();
+// singleWelcomeExample();


### PR DESCRIPTION
Node async fetch does not play well with wasm's synchronous host function execution. Rather than blocking the event loop in node to make wasm happy I've side-stepped wasm altogether in favor of an idiomatic async fetch.